### PR TITLE
fixed compile error

### DIFF
--- a/bobl/bson/details/encoder.hpp
+++ b/bobl/bson/details/encoder.hpp
@@ -14,6 +14,7 @@
 #include "bobl/utility/float.hpp"
 #include "bobl/utility/names.hpp"
 #include "bobl/utility/diversion.hpp"
+#include "bobl/names.hpp"
 #include "bobl/bobl.hpp"
 #include <boost/fusion/include/at.hpp>
 #include <boost/fusion/include/define_struct.hpp>


### PR DESCRIPTION
In file included from lib\bobl/bobl/bson/encode.hpp:4:0,
                 lib\bobl/bobl/bson/details/encoder.hpp: In member function 'Iterator bobl::bson::encoder::details::Handler<boost::variant<Params ...>, Options, typename bobl::utility::VariantUseTypeName<boost::variant<Params ...>, typename bobl::bson::EffectiveOptions<boost::variant<Params ...>, Options>::type>::type>::ValueVisitor<Iterator>::operator()(const T&) const':
lib\bobl/bobl/bson/details/encoder.hpp:264:16: error: 'TypeName' is not a member of 'bobl'
    auto name = bobl::TypeName<T>{}();
                ^